### PR TITLE
Remove PHP 7.3 env from Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 7.3
   - 7.4
   - 8.0
 


### PR DESCRIPTION
Remove PHP 7.3 env from Travis CI builds